### PR TITLE
Single Click Toggle Added

### DIFF
--- a/HeaderBar.js
+++ b/HeaderBar.js
@@ -6,21 +6,29 @@ class HeaderBar extends React.Component {
   constructor(){
 
     super();
-    this.enablePopoversAndTooltips();
   }
 
   // Enables the popover and tooltips to display their content when hovered over
   enablePopoversAndTooltips(){
-    this.changeButton();
-    // select all elements with the 'data-toggle = tooltip'
-    $(function () {
-      $('[data-toggle="tooltip"]').tooltip()
-    });
+
+    this.enablePopovers();
+    this.enableTooltips();
+  }
+
+  enablePopovers(){
 
     // select all elements with the 'data-toggle = popover'
     $(function () {
       $('[data-toggle="popover"]').popover()
     });
+  }
+
+  enableTooltips(){
+
+    // select all elements with the 'data-toggle = tooltip'
+      $(function () {
+        $('[data-toggle="tooltip"]').tooltip()
+      });
   }
 
   // Separately prevents the popovers on the page from displaying
@@ -41,7 +49,7 @@ class HeaderBar extends React.Component {
 
   // Calls both the functions that prevent the tooltips and popovers from displaying
   hidePopoversAndTooptips(){
-    this.changeButton();
+
     this.hidePopovers();
     this.hideTooltips();
   }
@@ -53,17 +61,39 @@ class HeaderBar extends React.Component {
     }
   }
 
-  //method to change button back and forth between on/off for tutorial
+  // Method to visually change button back and forth between on/off for tutorial
   changeButton(){
-    $('.btn-toggle').click(function() {
-      $(this).find('.btn').toggleClass('active');
-      if ($(this).find('.btn-primary').size()>0) {
-      	$(this).find('.btn').toggleClass('btn-primary');
-      }
-      $(this).find('.btn').toggleClass('btn-default');
-    });
 
+    var on = document.getElementById('button_on');
+    var off = document.getElementById('button_off');
+
+      if (on.className == "btn btn-default"){
+
+        on.className = "btn btn-primary active";
+        off.className = "btn btn-default";
+
+      }else if (off.className == "btn btn-default") {
+
+        off.className = "btn btn-primary active";
+        on.className = "btn btn-default";
+    }
   }
+
+    toggle(){
+
+      var on = document.getElementById('button_on');
+      var off = document.getElementById('button_off');
+
+      this.changeButton();
+
+      if (on.className == "btn btn-primary active"){
+
+        this.enablePopoversAndTooltips()
+
+      }else if (off.className == "btn btn-primary active") {
+        this.hidePopoversAndTooptips();
+      }
+    }
 
   render(){
     return (
@@ -86,8 +116,8 @@ class HeaderBar extends React.Component {
               </button>
 
               <div id = "toggle_groups" className = "btn-group btn-toggle" data-toggle = "buttons">
-                  <button className = "btn btn-default" id = "button_on" onClick = {this.enablePopoversAndTooltips.bind(this)} > ON </button>
-                  <button className = "btn btn-primary active" id = "button_off" onClick = {this.hidePopoversAndTooptips.bind(this)} > OFF </button>
+                  <button className = "btn btn-default" id = "button_on" onClick = {this.toggle.bind(this)} > ON </button>
+                  <button className = "btn btn-primary active" id = "button_off" onClick = {this.toggle.bind(this)} > OFF </button>
               </div>
             </div>
           </span>


### PR DESCRIPTION
# Problem

The toggle switch for the popovers and tooltips would only change their visual appearance on a double click, but the show/hide tooltips/popovers would still trigger on a single click. 
# Solution

A fix was implemented so that the toggle switch would change its visual appearance on a single click, and keep in pace with the hide/show feature. 
